### PR TITLE
Add CI environment variable to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ${SSH_AUTH_SOCK}:/ssh-agent
     environment:
+      - CI
       - NPM_TOKEN
       - GITHUB_TOKEN
       - BUILDKITE_JOB_ID


### PR DESCRIPTION
## Description

The docker-compose.yml was missing the CI environment variable which prevents semantic-release from recognising it is running in a CI environment and therefore does not produce a release.